### PR TITLE
chore: add step 4.3 example script

### DIFF
--- a/QEfficient/generation/step_4_3_example.py
+++ b/QEfficient/generation/step_4_3_example.py
@@ -1,0 +1,16 @@
+from QEfficient.generation.base_infer import BaseInferenceEngine
+from QEfficient.generation.spec_prefill import KeepConfig, SpecPrefillEngine
+from QEfficient.utils import load_hf_tokenizer
+
+spec_qpc = "/abs/path/to/spec/qpc"  # 8B spec with prefill_queries
+base_qpc = "/abs/path/to/base/qpc"  # 70B base
+tok = load_hf_tokenizer("meta-llama/Meta-Llama-3-8B")  # same tokenizer for both
+
+spec = SpecPrefillEngine(spec_qpc, tok, ctx_len=128, prefill_seq_len=16, device_ids=[0])
+base = BaseInferenceEngine(base_qpc, tok, ctx_len=128, prefill_seq_len=16, device_ids=[0])
+
+prompt = " ".join(["This is a longer prompt to force multiple chunks."] * 10)
+keep_cfg = KeepConfig(strategy="percentage", percentage=0.1, chunk=True, chunk_size=32)
+
+ret = spec.prune_and_base_prefill(base, prompt, pool_kernel_size=13, keep_cfg=keep_cfg)
+print(ret)


### PR DESCRIPTION
## Summary
- remove previous spec prune test
- add standalone script demonstrating `SpecPrefillEngine.prune_and_base_prefill`

## Testing
- `ruff check --fix QEfficient/generation/step_4_3_example.py`
- `ruff format QEfficient/generation/step_4_3_example.py`
- `python -m py_compile QEfficient/generation/step_4_3_example.py`
- `pre-commit run --files QEfficient/generation/step_4_3_example.py` *(fails: command not found)*
- `pytest --collect-only QEfficient/generation/step_4_3_example.py -q` *(fails: ModuleNotFoundError: No module named 'qaicrt')*


------
https://chatgpt.com/codex/tasks/task_e_68a514b913508332a3f521e1c1497b7a