### PR TITLE
Decode next token text in prefill debug output

### DIFF
--- a/QEfficient/generation/base_infer.py
+++ b/QEfficient/generation/base_infer.py
@@ -778,21 +778,29 @@ class QEffTextGenerationBase:
         # ---- debug-only prefill summary for parity with spec path ----
         try:
             import os
+
             if os.getenv("QEFF_BASE_DEBUG"):
                 orig_seq_len = int(position_ids.max())
                 logits = outputs.get("logits", None)
-                logits_shape = None if logits is None else tuple(getattr(logits, "shape", ()))
+                logits_shape = (
+                    None if logits is None else tuple(getattr(logits, "shape", ()))
+                )
                 # Print next-token argmax at the final prefill position
                 next_tok = None
+                next_tok_text = None
                 if logits is not None:
                     if logits.ndim == 2:
                         # [B,V] -> [B,1,V]
                         import numpy as _np
+
                         logits = _np.expand_dims(logits, 1)
                     next_tok = int(logits.argmax(2)[0, 0])
+                    next_tok_text = self.tokenizer.decode(
+                        [next_tok], skip_special_tokens=True
+                    )
                 print(
                     f"[base:prefill] orig_seq_len={orig_seq_len} padded_len={padded_len} chunks={num_chunks} "
-                    f"logits={logits_shape} next_tok={next_tok}"
+                    f"logits={logits_shape} next_tok_id={next_tok} next_tok_text={next_tok_text}"
                 )
         except Exception:
             pass


### PR DESCRIPTION
## Summary
- decode next-token id to human-readable text in `QEffTextGenerationBase.run_prefill` debug print

## Testing
- `python -m ruff check QEfficient/generation/base_infer.py`
- `python -m black --check QEfficient/generation/base_infer.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torchvision')*


------
https://chatgpt.com/codex/tasks/task_e_68ab976a9cb8833294f3d2efa6c7667f