### PR TITLE
Clarify prefill token debug logging

### DIFF
--- a/QEfficient/generation/base_infer.py
+++ b/QEfficient/generation/base_infer.py
@@ -800,7 +800,7 @@ class QEffTextGenerationBase:
                     )
                 print(
                     f"[base:prefill] orig_seq_len={orig_seq_len} padded_len={padded_len} chunks={num_chunks} "
-                    f"logits={logits_shape} next_tok_id={next_tok} next_tok_text={next_tok_text}"
+                    f"logits={logits_shape} next_tok_id={next_tok} next_tok_text={next_tok_text!r}"
                 )
         except Exception:
             pass

--- a/QEfficient/generation/spec_prefill.py
+++ b/QEfficient/generation/spec_prefill.py
@@ -242,7 +242,7 @@ class SpecPrefillEngine:
         import os
 
         if os.getenv("QEFF_SPEC_DEBUG", ""):
-            print(f"Prefill last token: {token_text}", flush=True)
+            print(f"[base:prefill] final token: {token_text!r}", flush=True)
         return outputs, position_ids, generation_len
 
     # --- helper to collect tensors for scoring from a prefill 'outputs' dict ---


### PR DESCRIPTION
## Summary
- show raw representation for `next_tok_text` in base prefill debug logging
- log raw final token string during speculative prefill

## Testing
- `pre-commit run --files QEfficient/generation/spec_prefill.py QEfficient/generation/base_infer.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not connect to proxy to download pre-commit)*
- `pytest` *(fails: KeyboardInterrupt while loading tests; missing dependencies such as boto3)*

------
https://chatgpt.com/codex/tasks/task_e_68aba631a0c883329049814bcd929f76