### PR TITLE
Add two-pass global scoring option for spec prefill

### DIFF
--- a/QEfficient/generation/run_spec_prefill.py
+++ b/QEfficient/generation/run_spec_prefill.py
@@ -45,6 +45,10 @@ def main() -> None:
     parser.add_argument(
         "--no-chunk", action="store_true", help="Disable chunked keep; use per-token percentage."
     )
+    parser.add_argument(
+        "--global-score", action="store_true",
+        help="Two-pass spec scoring over all windows; keep percentage over the entire prompt."
+    )
     args = parser.parse_args()
 
     os.environ.setdefault("QEFF_SPEC_DEBUG", "1")
@@ -112,6 +116,7 @@ def main() -> None:
         pool_kernel_size=13,
         keep_cfg=keep_cfg,
         prefill_logit_bs=1,
+        global_score=args.global_score,
     )
     print("[k=0 integration]", ret)
 


### PR DESCRIPTION
## Summary
- add `global_score` flag to speculative prefill to enable a streamed two-pass importance computation
- expose `--global-score` CLI flag and thread through run_spec_prefill

## Testing
- `python3 -m py_compile QEfficient/generation/spec_prefill.py QEfficient/generation/run_spec_prefill.py`
- `python3 -m pytest` *(fails: No module named pytest; attempted `pip install pytest` but received 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68adb1025df0833281d581e5836b41d9