### PR TITLE
Use float precision for importance_chunk

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -353,7 +353,7 @@ class QEFFBaseModel(ABC):
                 for io_name, dtype in custom_io.items():
                     fp.write(f" - IOName: {io_name}\n   Precision: {dtype}\n\n")
                 if os.getenv("QEFF_DEVICE_SCORING") == "1":
-                    fp.write(" - IOName: importance_chunk\n   Precision: float32\n\n")
+                    fp.write(" - IOName: importance_chunk\n   Precision: float\n\n")
             command.append(f"-custom-IO-list-file={custom_io_yaml}")
 
         command.append(f"-aic-binary-dir={qpc_path}")


### PR DESCRIPTION
## Summary
- set device scoring custom IO `importance_chunk` precision to float

## Testing
- `python -m QEfficient.cloud.infer --model-name meta-llama/Llama-3.2-1B-Instruct --batch-size 1 --prompt-len 128 --ctx-len 4096 --num-cores 16 --device_group [0] --prompt "Hello" --mxfp6-matmul --allow-mxint8-mdp-io --aic-enable-depth-first` *(fails: ModuleNotFoundError: No module named 'qaicrt')*
- `python - <<'PY'
from QEfficient.generation.cloud_infer import QAICInferenceSession
s = QAICInferenceSession('/path/to/spec/qpc', device_ids=[0])
print('outputs:', s.output_names)
PY` *(fails: ModuleNotFoundError: No module named 'qaicrt')*
- `python -m QEfficient.generation.run_spec_prefill --spec-qpc /path/to/spec/qpc --base-qpc /path/to/base/qpc --model-name meta-llama/Llama-3.2-1B-Instruct --prompt "This is a longer prompt to exercise multiple chunks. " --ctx-len 4096 --gen-len 16 --spec-device-ids [0] --base-device-ids [1] --keep-percentage 0.10 --no-chunk` *(fails: ModuleNotFoundError: No module named 'qaicrt')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'torchvision')*


------
https://chatgpt.com/codex/tasks/task_e_68ae7a10f5ac833290c7c304c6acda60