### PR TITLE
Fix device scoring transform usage

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -195,7 +195,7 @@ class QEFFBaseModel(ABC):
 
             transforms = list(self._onnx_transforms)
             if os.getenv("QEFF_DEVICE_SCORING") == "1":
-                transforms.append(AttachSpecPrefillScoring())
+                transforms.append(AttachSpecPrefillScoring)
             for transform in transforms:
                 model, transformed = transform.apply(model, **transform_kwargs)
             # Debug: confirm presence of importance_chunk when device scoring is on

--- a/QEfficient/base/onnx_transforms.py
+++ b/QEfficient/base/onnx_transforms.py
@@ -105,7 +105,8 @@ class SplitTensorsTransform(OnnxTransform):
 class AttachSpecPrefillScoring(OnnxTransform):
     """Inject per-chunk token-importance scoring into the speculator graph."""
 
-    def apply(self, model: onnx.ModelProto, **kwargs) -> Tuple[onnx.ModelProto, bool]:
+    @staticmethod
+    def apply(model: onnx.ModelProto, **kwargs) -> Tuple[onnx.ModelProto, bool]:
         g = model.graph
         changed = False
 


### PR DESCRIPTION
## Summary
- make `AttachSpecPrefillScoring.apply` a static method so transform classes aren't instantiated
- append `AttachSpecPrefillScoring` class instead of an instance when device scoring is enabled

## Testing
- `pre-commit run --files QEfficient/base/onnx_transforms.py QEfficient/base/modeling_qeff.py` *(command not found)*
- `pytest` *(ModuleNotFoundError: No module named 'torchvision')*

------
https://chatgpt.com/codex/tasks/task_e_68ae85a1b3248332847327de0a876f57