### PR TITLE
Skip device scoring output during decode

### DIFF
--- a/QEfficient/generation/text_generation_inference.py
+++ b/QEfficient/generation/text_generation_inference.py
@@ -706,19 +706,6 @@ class QEffTextGenerationBase:
         logits_out_placeholder = np.zeros((prefill_logit_bs, 1, self._vocab_size), dtype=np.float32)
         self._session.set_buffers({"logits": logits_out_placeholder})
 
-        # Bind device-scoring output (prefill specialization) if present
-        if "importance_chunk" in self._session.output_names:
-            try:
-                idx = self._session.binding_index_map["importance_chunk"]
-                # Use the selected-set binding dims for prefill (typically [1, 128, 2048])
-                imp_shape = tuple(self._session.bindings[idx].dims)
-                self._session.set_buffers({"importance_chunk": np.zeros(imp_shape, dtype=np.float16)})
-            except Exception as e:
-                # Non-fatal: just skip binding if anything unexpected
-                # (keeps host-side scoring fallback intact)
-                if os.getenv("QEFF_SPEC_DEBUG", ""):
-                    print(f"[prefill] importance_chunk bind skipped: {e}", flush=True)
-
         inputs = self.tokenizer(prompt, return_tensors="np", padding="max_length", max_length=padded_len)
         inputs["position_ids"] = np.where(inputs.pop("attention_mask"), np.arange(padded_len), -1)
         inputs.pop("token_type_ids", None)
@@ -771,6 +758,9 @@ class QEffTextGenerationBase:
             (self.full_batch_size, self._decode_seq_len, self._vocab_size), dtype=np.float32
         )
         self._session.set_buffers({"logits": logits_out_placeholder})
+        # Skip device-scoring output for decode specialization in CB mode as well
+        if "importance_chunk" in self._session.output_names:
+            self._session.skip_buffers(["importance_chunk"])
         # Generate flag for tracking progress for each batch ID
         current_decode_ongoing = np.full((self.full_batch_size, 1), True)
 
@@ -848,15 +838,15 @@ class QEffTextGenerationBase:
         Returns:
             num_token (int): The number of tokens processed in the decoding process.
         """
-        # Skip device-scoring output for decode specialization unless you intend to consume it
-        if "importance_chunk" in self._session.output_names:
-            self._session.skip_buffers(["importance_chunk"])
 
         if self.is_tlm:
             logits_out_placeholder = np.zeros(
                 (self.batch_size, self._decode_seq_len, self._vocab_size), dtype=np.float32
             )
             self._session.set_buffers({"logits": logits_out_placeholder})
+        # Skip device-scoring output for decode specialization (we don't consume it here)
+        if "importance_chunk" in self._session.output_names:
+            self._session.skip_buffers(["importance_chunk"])
         finished_sequences = decode_inputs["input_ids"] == self.tokenizer.eos_token_id
         num_token = 0
         for num_token in range(1, generation_len):


### PR DESCRIPTION
## Summary
- Avoid binding `importance_chunk` during prefill so QPC specialization dictates output shape
- Skip `importance_chunk` for decode and continuous batching decode since it's unused

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torchvision')*
- `pip install torchvision` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68af16baab0c833297c795ecf010022c