### PR TITLE
Skip device scoring buffer binding

### DIFF
--- a/QEfficient/generation/cloud_infer.py
+++ b/QEfficient/generation/cloud_infer.py
@@ -97,6 +97,9 @@ class QAICInferenceSession:
         self.buf_dims = qaicrt.BufferDimensionsVecRef(
             [(aic_to_np_dtype_mapping[binding.type].itemsize, list(binding.dims)) for binding in self.bindings]
         )
+        # Always skip device-scoring output binding (shape is specialization-dependent and not consumed here)
+        if "importance_chunk" in self.output_names:
+            self.skip_buffers(["importance_chunk"])
         # Debug: show compiled dims for importance_chunk once
         try:
             if "importance_chunk" in self.output_names:

--- a/QEfficient/generation/text_generation_inference.py
+++ b/QEfficient/generation/text_generation_inference.py
@@ -848,7 +848,7 @@ class QEffTextGenerationBase:
                 (self.batch_size, self._decode_seq_len, self._vocab_size), dtype=np.float32
             )
             self._session.set_buffers({"logits": logits_out_placeholder})
-        # We don't consume device-scoring output during decode either
+        # Not consuming device scoring output during decode – ensure it stays skipped
         if "importance_chunk" in self._session.output_names:
             self._session.skip_buffers(["importance_chunk"])
         finished_sequences = decode_inputs["input_ids"] == self.tokenizer.eos_token_id


### PR DESCRIPTION
## Summary
- ignore `importance_chunk` binding globally in `QAICInferenceSession` to avoid mismatched output shapes
- explicitly skip `importance_chunk` during decode as well

## Testing
- `pytest` *(fails: KeyboardInterrupt during import)*

------
https://chatgpt.com/codex/tasks/task_e_68af22d8228c833284b1958b8b600913