### PR TITLE
Broadcast importance_chunk to 3D tensor

### DIFF
--- a/QEfficient/generation/cloud_infer.py
+++ b/QEfficient/generation/cloud_infer.py
@@ -97,14 +97,14 @@ class QAICInferenceSession:
         self.buf_dims = qaicrt.BufferDimensionsVecRef(
             [(aic_to_np_dtype_mapping[binding.type].itemsize, list(binding.dims)) for binding in self.bindings]
         )
-        # Always skip device-scoring output binding (shape is specialization-dependent and not consumed here)
-        if "importance_chunk" in self.output_names:
-            self.skip_buffers(["importance_chunk"])
-        # Debug: show compiled dims for importance_chunk once
+        # Debug: show compiled dims for device scoring output if present
         try:
             if "importance_chunk" in self.output_names:
                 idx = self.binding_index_map["importance_chunk"]
-                print(f"[qaic:init] importance_chunk compiled dims={self.bindings[idx].dims}", flush=True)
+                print(
+                    f"[qaic:init] importance_chunk compiled dims={self.bindings[idx].dims}",
+                    flush=True,
+                )
         except Exception:
             pass
 
@@ -146,9 +146,6 @@ class QAICInferenceSession:
                 buffer.itemsize,
                 buffer.shape if len(buffer.shape) > 0 else (1,),
             )
-            # Debug: log any overrides to importance_chunk dims
-            if buffer_name == "importance_chunk":
-                print(f"[qaic:set] importance_chunk override shape={buffer.shape}", flush=True)
 
     def skip_buffers(self, skipped_buffer_names: List[str]):
         """
@@ -172,13 +169,6 @@ class QAICInferenceSession:
         """
         # Set inputs
         self.set_buffers(inputs)
-        # Debug: print current buf_dims for importance_chunk prior to submit
-        try:
-            if "importance_chunk" in self.output_names:
-                idx = self.binding_index_map["importance_chunk"]
-                print(f"[qaic:run] importance_chunk buf_dims={self.buf_dims[idx][1]}", flush=True)
-        except Exception:
-            pass
         if self.execObj.setData(self.qbuffers, self.buf_dims) != qaicrt.QStatus.QS_SUCCESS:
             raise MemoryError("Failed to setData")
         # # Run with sync API


### PR DESCRIPTION
## Summary
- expand `importance_chunk` to a `[1, S_cap, hidden]` tensor during ONNX transform
- remove device-scoring buffer overrides from cloud inference utilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torchvision')*
- `python -m QEfficient.cloud.infer --model-name meta-llama/Llama-3.2-1B-Instruct --batch-size 1 --prompt-len 128 --ctx-len 4096 --num-cores 16 --device_group [0] --prompt "Hello" --mxfp6-matmul --allow-mxint8-mdp-io --aic-enable-depth-first` *(fails: ModuleNotFoundError: No module named 'qaicrt')*

------
https://chatgpt.com/codex/tasks/task_e_68af26e23c988332a8f1ad8fabcacd3c