### PR TITLE
Add debug prints for importance_chunk binding shapes

### DIFF
--- a/QEfficient/generation/cloud_infer.py
+++ b/QEfficient/generation/cloud_infer.py
@@ -82,6 +82,13 @@ class QAICInferenceSession:
         ]
         self.bindings = iodesc.selected_set.bindings
         self.binding_index_map = {binding.name: binding.index for binding in self.bindings}
+        idx = self.binding_index_map.get("importance_chunk")
+        if idx is not None:
+            print("[qaic:init] imp_chunk compiled dims =", self.bindings[idx].dims)
+            print(
+                "[qaic:init] imp_chunk allowed =",
+                [x[idx][1] for x in self.allowed_shapes],
+            )
         # Create and load Program
         prog_properties = qaicrt.QAicProgramProperties()
         prog_properties.SubmitRetryTimeoutMs = 60_000


### PR DESCRIPTION
## Summary
- log compiled and allowed shapes for `importance_chunk` in QAIC inference session initialization

## Testing
- `python -m QEfficient.cloud.infer --model-name meta-llama/Llama-3.2-1B-Instruct --batch-size 1 --prompt-len 128 --ctx-len 4096 --num-cores 16 --device_group [0] --prompt "Hello" --mxfp6-matmul --aic-enable-depth-first --force-reexport` *(fails: ModuleNotFoundError: No module named 'qaicrt')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'torchvision')*


------
https://chatgpt.com/codex/tasks/task_e_68af479be9a88332b27f893a6f47c917