### PR TITLE
Remove temporary kwargs plumbing and debug prints

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -194,15 +194,6 @@ class QEFFBaseModel(ABC):
             }
             if onnx_transform_kwargs is not None:
                 transform_kwargs.update(onnx_transform_kwargs)
-            # debug print once
-            try:
-                print(
-                    f"[export] onnx_transform_kwargs: seq_len={transform_kwargs.get('seq_len')} "
-                    f"hidden_size={transform_kwargs.get('hidden_size')}",
-                    flush=True,
-                )
-            except Exception:
-                pass
 
             import os
             from QEfficient.base.onnx_transforms import AttachProbeOutput

--- a/QEfficient/base/onnx_transforms.py
+++ b/QEfficient/base/onnx_transforms.py
@@ -116,13 +116,6 @@ class AttachProbeOutput(OnnxTransform):
         # Read compile-time export hints; fallback to safe defaults.
         S = int(kwargs.get("seq_len", 32))
         H = int(kwargs.get("hidden_size", 2048))
-        try:
-            print(
-                f"[transform] {type(AttachProbeOutput).__name__} kwargs: seq_len={S}, hidden_size={H}",
-                flush=True,
-            )
-        except Exception:
-            pass
 
         # Build INT64 shape [1, S, H] as an initializer
         shape_name = "probe_shape_i64"

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -1612,25 +1612,11 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
                 dynamic_axes=dynamic_axes,
             )
 
-        # ---- pass shape hints to ONNX transforms (seq_len, hidden_size) ----
-        try:
-            # Use the actual export example sequence length
-            export_seq_len = int(example_inputs["position_ids"].shape[1])
-        except Exception:
-            export_seq_len = int(getattr(constants, "ONNX_EXPORT_EXAMPLE_SEQ_LEN", 32))
-        export_hidden = int(getattr(self.model.config, "hidden_size", 2048))
-
-        onnx_transform_kwargs = {
-            "seq_len": export_seq_len,
-            "hidden_size": export_hidden,
-        }
-
         return self._export(
             example_inputs=example_inputs,
             output_names=output_names,
             dynamic_axes=dynamic_axes,
             export_dir=export_dir,
-            onnx_transform_kwargs=onnx_transform_kwargs,
         )
 
     def get_sampling_inputs_and_outputs(


### PR DESCRIPTION
## Summary
- drop kwargs pass-through during export in modeling_auto
- remove temporary debug print for transform kwargs
- eliminate verbose print from AttachProbeOutput transform

## Testing
- `pre-commit run --files QEfficient/transformers/models/modeling_auto.py QEfficient/base/modeling_qeff.py QEfficient/base/onnx_transforms.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: No matching distribution found: proxy 403)*
- `python -m QEfficient.cloud.infer --model-name meta-llama/Llama-3.2-1B-Instruct --batch-size 1 --prompt-len 128 --ctx-len 4096 --num-cores 16 --device_group [0] --prompt "Hello" --mxfp6-matmul --aic-enable-depth-first` *(fails: ModuleNotFoundError: No module named 'qaicrt')*

------
https://chatgpt.com/codex/tasks/task_e_68af976183988332a3413f520ce70651