### PR TITLE
feat: log importance_chunk shapes

### DIFF
--- a/QEfficient/generation/text_generation_inference.py
+++ b/QEfficient/generation/text_generation_inference.py
@@ -735,6 +735,12 @@ class QEffTextGenerationBase:
             outputs = self._session.run(chunk_inputs)
             if self._write_io_dir is not None:
                 write_io_files(inputs, outputs, self._write_io_dir, "prefill", "aic_batch_io", True, False)
+        # --- probe: log importance_chunk shape after prefill (last chunk) ---
+        try:
+            if os.getenv("QEFF_SPEC_DEBUG") and "importance_chunk" in outputs:
+                print(f"[probe] prefill importance_chunk shape={tuple(outputs['importance_chunk'].shape)}", flush=True)
+        except Exception:
+            pass
         return (
             outputs,
             position_ids,
@@ -842,11 +848,22 @@ class QEffTextGenerationBase:
             )
             self._session.set_buffers({"logits": logits_out_placeholder})
         finished_sequences = decode_inputs["input_ids"] == self.tokenizer.eos_token_id
+        # one-time probe flag for importance shape in decode
+        _printed_decode_imp = getattr(self, "_printed_decode_imp", False)
         num_token = 0
         for num_token in range(1, generation_len):
             if streamer:
                 streamer.put(decode_inputs["input_ids"][0])
             outputs = self._session.run(decode_inputs)
+            # --- probe: log importance_chunk shape on first decode step ---
+            if not _printed_decode_imp:
+                try:
+                    if os.getenv("QEFF_SPEC_DEBUG") and "importance_chunk" in outputs:
+                        print(f"[probe] decode importance_chunk shape={tuple(outputs['importance_chunk'].shape)}", flush=True)
+                        _printed_decode_imp = True
+                        setattr(self, "_printed_decode_imp", True)
+                except Exception:
+                    pass
 
             if self._write_io_dir is not None:
                 write_io_files(decode_inputs, outputs, self._write_io_dir, "decode", "aic_batch_io", True, False)


### PR DESCRIPTION
## Summary
- print `importance_chunk` shape after prefill when `QEFF_SPEC_DEBUG=1`
- print `importance_chunk` shape on first decode step when `QEFF_SPEC_DEBUG=1`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torchvision')*
- `python -m QEfficient.cloud.infer --model-name meta-llama/Llama-3.2-1B-Instruct --batch-size 1 --prompt-len 128 --ctx-len 4096 --num-cores 16 --device_group [0] --prompt "Hello" --mxfp6-matmul --aic-enable-depth-first --allow-mxint8-mdp-io` *(fails: ModuleNotFoundError: No module named 'qaicrt')*

------
https://chatgpt.com/codex/tasks/task_e_68b0b32878b08332a2aefff6ca101ee0