### PR TITLE
Preserve absolute positions for speculative prefill and capture pruned decode

### DIFF
--- a/QEfficient/generation/run_spec_prefill.py
+++ b/QEfficient/generation/run_spec_prefill.py
@@ -119,6 +119,7 @@ def main() -> None:
         keep_cfg=keep_cfg,
         prefill_logit_bs=1,
         layers_sel=args.layers_for_scoring,
+        gen_len=int(args.gen_len) if args.gen_len is not None else None,
     )
     print("[k=0 integration]", ret)
 


### PR DESCRIPTION
## Summary
- return `pos_global` from `prefill_and_score` and feed original positions into pruned base prefill
- optionally run decode after pruned prefill and surface the generated text
- allow CLI to pass `--gen-len` through to `prune_and_base_prefill`

## Testing
- `pre-commit run --files QEfficient/generation/spec_prefill.py QEfficient/generation/run_spec_prefill.py` *(command not found)*
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'torchvision')*


------
https://chatgpt.com/codex/tasks/task_e_68b3621dfb68833288b1b993e5020b26