### PR TITLE
Optimize spec prefill by skipping unused past_key outputs

### DIFF
--- a/QEfficient/generation/run_spec_prefill.py
+++ b/QEfficient/generation/run_spec_prefill.py
@@ -80,6 +80,8 @@ def main() -> None:
         ctx_len=int(args.ctx_len),
         device_id=spec_device_ids,
     )
+    # Set which layers to keep for scoring
+    spec._layers_sel = args.layers_for_scoring
     base = TextGeneration(
         tokenizer=tokenizer,
         qpc_path=args.base_qpc,


### PR DESCRIPTION
## Summary
- allow choosing which layers' past_key outputs to keep for host scoring
- skip past_key RetainedState buffers for unselected layers to cut I/O overhead
- expose layer selection in the CLI by threading `--layers-for-scoring` to the spec engine

## Testing
- `python -m py_compile QEfficient/generation/spec_prefill.py QEfficient/generation/run_spec_prefill.py`
- `pytest` *(fails: KeyboardInterrupt during heavy dependency import)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d03f48548332af7ef5e34e5628ac