### PR TITLE
Fetch retained keys only on final prefill chunk

### DIFF
--- a/QEfficient/generation/cloud_infer.py
+++ b/QEfficient/generation/cloud_infer.py
@@ -168,6 +168,24 @@ class QAICInferenceSession:
 
         self.set_buffers({k: np.array([]) for k in skipped_buffer_names})
 
+    def enable_outputs(self, names: List[str]):
+        """
+        Re-enable reading specific output bindings that were previously skipped,
+        by allocating QBuffers of the compiled size and restoring dims from the
+        selected_set. Use only for OUTPUT bindings.
+        """
+        for name in names:
+            if name not in self.binding_index_map:
+                continue
+            idx = self.binding_index_map[name]
+            binding = self.bindings[idx]
+            # Allocate a QBuffer of the compiled size for this binding
+            self.qbuffers[idx] = qaicrt.QBuffer(bytes(binding.size))
+            # Restore dims from the compiled (selected) set
+            # itemsize is already known from type
+            itemsize = aic_to_np_dtype_mapping[binding.type].itemsize
+            self.buf_dims[idx] = (itemsize, list(binding.dims))
+
     def run(self, inputs: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
         """
         Execute on cloud AI 100


### PR DESCRIPTION
## Summary
- add enable_outputs helper to re-enable skipped output bindings
- run spec prefill without fetching past_key buffers on intermediate chunks and harvest retained keys once
- assemble global keys from final retained-state slice to avoid per-chunk concatenation overhead

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torchvision')*
- `pip install torchvision` *(fails: Could not find a version that satisfies the requirement torchvision, proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e34fa830833286628ff959646edc