### PR TITLE
fix prefill buffer restoration

### DIFF
--- a/QEfficient/generation/spec_prefill.py
+++ b/QEfficient/generation/spec_prefill.py
@@ -194,13 +194,9 @@ class SpecPrefillEngine:
         max_gen_len = self._ctx_len - position_ids.max()
         generation_len = self._fetch_generation_len(generation_len, max_gen_len)
 
-        logits_out_placeholder = np.zeros(
-            (prefill_logit_bs, 1, self._vocab_size), dtype=np.float32
-        )
-        self._session.set_buffers({"logits": logits_out_placeholder})
-
-        # NOTE: we will only bind a logits placeholder on the FINAL chunk (if we print final token).
-        # Per-chunk gating of outputs is handled inside the loop.
+        # NOTE: we will only bind a logits placeholder on the FINAL chunk (if we
+        # print the final token). Per-chunk gating of outputs is handled inside
+        # the loop.
 
         inputs = self.tokenizer(
             prompt, return_tensors="np", padding="max_length", max_length=padded_len
@@ -283,16 +279,22 @@ class SpecPrefillEngine:
             if want_logits:
                 gate_names.append("logits")
             if i != num_chunks - 1:
-                try:
-                    self._session.skip_buffers(gate_names)
-                except Exception:
-                    pass
+                # Non-final: skip these outputs entirely
+                self._session.skip_buffers(gate_names)
             else:
-                try:
-                    self._session.enable_outputs(["prefill_queries"])
-                except Exception:
-                    pass
+                # Final: restore prefill_queries (and logits if needed) to proper buffers+dims
+                self._session.enable_outputs(["prefill_queries"])
+                if os.getenv("QEFF_SPEC_DEBUG", ""):
+                    idx = self._session.binding_index_map.get("prefill_queries")
+                    if idx is not None:
+                        print(
+                            "[spec:gate] prefill_queries buf_dims restored to",
+                            self._session.buf_dims[idx],
+                            flush=True,
+                        )
                 if want_logits:
+                    # either restore via enable_outputs OR provide a placeholder
+                    # choose one path; here we re-bind logits as placeholder
                     logits_out_placeholder = np.zeros(
                         (prefill_logit_bs, 1, self._vocab_size), dtype=np.float32
                     )


### PR DESCRIPTION
## Summary
- add enable_outputs helper to recreate QBuffers and dims for skipped outputs
- gate prefill outputs per chunk and restore on final chunk with debug print

## Testing
- `pytest tests/cloud/test_infer.py::test_infer -q` *(fails: No module named 'torchvision')*


------
https://chatgpt.com/codex/tasks/task_e_68b3fcf807d48332bf80c38de398207f