### PR TITLE
chore: remove retained-state compilation logic

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -282,9 +282,6 @@ class QEFFBaseModel(ABC):
             return self.qpc_path
 
         command = constants.COMPILER + [f"-m={onnx_path}"]
-        # Always expose retained-state for KV harvesting
-        if "-retained-state" not in command:
-            command.append("-retained-state")
 
         if mdp_ts_json_path := compiler_options.pop("mdp_load_partition_config", None):
             command.append(f"-mdp-load-partition-config={mdp_ts_json_path}")
@@ -350,47 +347,13 @@ class QEFFBaseModel(ABC):
             create_json(str(specializations_json), specializations_data)
             command.append(f"-network-specialization-config={specializations_json}")
 
-        # --- Ensure selected I/O keeps retained-state + research heads ---
-        # If caller didn't provide custom_io, synthesize one from ONNX outputs so the compiler
-        # doesn't elide retained-state in MDP/TS builds.
-        custom_map = dict(custom_io) if custom_io is not None else {}
-        if not custom_map:
-            try:
-                import onnx, re
-                model_onnx = onnx.load(str(onnx_path), load_external_data=False)
-                out_names = [o.name for o in model_onnx.graph.output]
-                # Collect all past_key/past_value retained-state outputs
-                rk = [n for n in out_names if re.search(r"past_key\.\d+.*_RetainedState", n)]
-                rv = [n for n in out_names if re.search(r"past_value\.\d+.*_RetainedState", n)]
-                if not rk and not rv:
-                    # If the ONNX itself lacks retained-state outputs, fail fast with context.
-                    raise RuntimeError(
-                        "[compile] ONNX has no retained-state outputs in graph.output; "
-                        "cannot force keys into selected I/O. Re-check exporter/output_names."
-                    )
-                for n in rk:
-                    custom_map.setdefault(n, "float16")
-                for n in rv:
-                    custom_map.setdefault(n, "float16")
-                if "prefill_queries" in out_names:
-                    custom_map.setdefault("prefill_queries", "float32")
-                if "logits" in out_names:
-                    custom_map.setdefault("logits", "float32")
-            except Exception as e:
-                # Still guarantee research/logits appear, but surface the error for visibility
-                logger.warning(f"[compile] custom_io synthesize warning: {e}")
-                custom_map.setdefault("prefill_queries", "float32")
-                custom_map.setdefault("logits", "float32")
-
-        if custom_map:
+        # Write custom_io.yaml file
+        if custom_io is not None:
             custom_io_yaml = compile_dir / "custom_io.yaml"
             with open(custom_io_yaml, "w") as fp:
-                for io_name, dtype in custom_map.items():
+                for io_name, dtype in custom_io.items():
                     fp.write(f" - IOName: {io_name}\n   Precision: {dtype}\n\n")
             command.append(f"-custom-IO-list-file={custom_io_yaml}")
-            logger.info(
-                f"[compile] custom_io.yaml wrote {len(custom_map)} I/O; retained-state preserved in selected set."
-            )
 
         command.append(f"-aic-binary-dir={qpc_path}")
         logger.info(f"Running compiler: {' '.join(command)}")


### PR DESCRIPTION
## Summary
- simplify `compile` to omit automatic retained-state flag
- drop custom I/O synthesis for retained-state handling

## Testing
- `python -m py_compile QEfficient/base/modeling_qeff.py`
- `pytest tests/base/test_modeling_qeff.py -q` *(fails: ModuleNotFoundError: No module named 'torchvision')*

------
https://chatgpt.com/codex/tasks/task_e_68b604749338833286879c2c00c070cd