### PR TITLE
Implement block top-k and optional look-ahead for speculative prefill

### DIFF
--- a/QEfficient/generation/run_spec_prefill.py
+++ b/QEfficient/generation/run_spec_prefill.py
@@ -46,6 +46,12 @@ def main() -> None:
         "--no-chunk", action="store_true", help="Disable chunked keep; use per-token percentage."
     )
     parser.add_argument(
+        "--look-ahead",
+        type=int,
+        default=0,
+        help="Number of decode anchors for look-ahead (default: 0).",
+    )
+    parser.add_argument(
         "--layers-for-scoring",
         default="all",
         choices=["all", "last4", "last1"],
@@ -171,6 +177,7 @@ def main() -> None:
         prefill_logit_bs=1,
         layers_sel=args.layers_for_scoring,
         gen_len=int(args.gen_len) if args.gen_len is not None else None,
+        look_ahead=int(args.look_ahead),
     )
 
     # --- Pretty, accurate TTFT breakdown ---


### PR DESCRIPTION
## Summary
- change layer aggregation from mean to max for speculative importance
- add block-wise Top-K selection with fallback to global Top-K
- support optional look-ahead anchors and expose `--look-ahead` CLI flag

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torchvision')*
- `pip install torchvision -q` *(fails: Could not find a version that satisfies the requirement torchvision)*

------
https://chatgpt.com/codex/tasks/task_e_68b89dae5cec83328c4e8d69dacaef66