### PR TITLE
Always print spec invariants in SpecPrefillEngine

### DIFF
--- a/QEfficient/generation/spec_prefill.py
+++ b/QEfficient/generation/spec_prefill.py
@@ -634,13 +634,12 @@ class SpecPrefillEngine:
         assert D_k == D, f"D mismatch Q vs K: Dq={D}, Dk={D_k}"
         assert H % H_kv == 0, f"GQA mismatch: H={H}, H_kv={H_kv} (H must be a multiple of H_kv)"
         group_size = H // H_kv
-        if os.getenv("QEFF_SPEC_DEBUG", ""):
-            # Example: [spec:invariants] S_total=64539 Q_final=(32,32,128) K0=(8,64539,128) H=32 H_kv=8 group=4
-            print(
-                f"[spec:invariants] S_total={S} Q_final=({L},{H},{D}) "
-                f"K0=({H_kv},{S},{D_k}) H={H} H_kv={H_kv} group={group_size}",
-                flush=True,
-            )
+        # Example: [spec:invariants] S_total=64539 Q_final=(32,32,128) K0=(8,64539,128) H=32 H_kv=8 group=4
+        print(
+            f"[spec:invariants] S_total={S} Q_final=({L},{H},{D}) "
+            f"K0=({H_kv},{S},{D_k}) H={H} H_kv={H_kv} group={group_size}",
+            flush=True,
+        )
 
         # precompute sqrt(D)
         scale = 1.0 / math.sqrt(float(D))


### PR DESCRIPTION
## Summary
- always show GQA invariants in `spec_prefill.py` by removing `QEFF_SPEC_DEBUG` guard

## Testing
- `python -m py_compile QEfficient/generation/spec_prefill.py`
- `pre-commit run --files QEfficient/generation/spec_prefill.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: No matching distribution found for pre-commit)*
- `pytest tests -k spec_prefill` *(fails: ModuleNotFoundError: No module named 'torchvision')*
- `pip install torchvision` *(fails: No matching distribution found for torchvision)*

------
https://chatgpt.com/codex/tasks/task_e_68c733dea8288332a6d566efc4178635