### PR TITLE
Remove redundant ONNX import in modeling_qeff

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -265,8 +265,6 @@ class QEFFBaseModel(ABC):
 
             # Save model with external data file next to the .onnx (always create one file)
             try:
-                import onnx
-
                 onnx.save_model(
                     model,
                     str(onnx_path),


### PR DESCRIPTION
## Summary
- remove the redundant local `onnx` import before calling `onnx.save_model` in `modeling_qeff`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd9cda754c8332a8dafbd61cb8a5d1