### PR TITLE
Remove redundant os imports in modeling_qeff

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -276,7 +276,6 @@ class QEFFBaseModel(ABC):
                     size_threshold=1024,
                 )
                 # Verify: non-trivial ONNX size OR sidecar present OR uses_external_data reported
-                import os
                 from onnx.external_data_helper import uses_external_data
 
                 onnx_bytes = os.path.getsize(onnx_path)
@@ -304,8 +303,6 @@ class QEFFBaseModel(ABC):
                     onnx.save(model, str(onnx_path))
                 # Optionally, re-verify size
                 try:
-                    import os
-
                     print(
                         f"[export] external save verification failed; wrote embedded weights. onnx_size={os.path.getsize(onnx_path)}"
                     )


### PR DESCRIPTION
## Summary
- remove redundant local `os` imports in `QEfficient/base/modeling_qeff.py`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cda43d045c83328aded573d95e085c