### PR TITLE
Ensure ONNX export loads externals from tmp and validates raw data

### DIFF
--- a/QEfficient/base/onnx_transforms.py
+++ b/QEfficient/base/onnx_transforms.py
@@ -90,7 +90,9 @@ class SplitTensorsTransform(OnnxTransform):
         """
         # Ensure any existing externals are loaded to raw_data before conversion
         try:
-            external_data_helper.load_external_data_for_model(model, onnx_base_dir)
+            load_dir = kwargs.get("load_external_dir", onnx_base_dir)
+            if load_dir:
+                external_data_helper.load_external_data_for_model(model, load_dir)
         except Exception:
             pass
         # Convert using the official helper; this does not destroy raw_data until save_model


### PR DESCRIPTION
## Summary
- ensure exported models load external tensors from the temporary directory before transformation
- validate that ONNX initializers retain raw data before saving and propagate the source directory to transforms
- allow SplitTensorsTransform to honor a configurable external-data load directory

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cdb81ac00c8332af1eb77c239206a1